### PR TITLE
[PEER-155] Moderator User doesn't see the Display names of users who hadn't performed transactions

### DIFF
--- a/src/user.ts
+++ b/src/user.ts
@@ -43,6 +43,8 @@ export function getIpfsUserData(user: User | null): void {
       let displayName = ipfsObj.get('displayName');
       if (!displayName.isNull()) {
         user.displayName = displayName.toString();
+      } else {
+        user.displayName = user.id.slice(0,6) + '...' + user.id.slice(-4);
       }
       
       let company = ipfsObj.get('company');


### PR DESCRIPTION
Graph isn't indexing users' Display Names if they hadn't performed transactions yet.